### PR TITLE
Add functionality to get SATA SMART attribute flag prefailure and online bits

### DIFF
--- a/examples/sata_linux_test.go
+++ b/examples/sata_linux_test.go
@@ -54,8 +54,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 6, int(thr.Thresholds[1]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 3:
 			require.Equal(t, "Spin_Up_Time", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -63,8 +63,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 16, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[3]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 4:
 			require.Equal(t, "Start_Stop_Count", a.Name)
 			require.Equal(t, 0x0002, int(a.Flags))
@@ -72,8 +72,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 100, int(a.ValueRaw))
 			require.Equal(t, 20, int(thr.Thresholds[4]))
-			require.Equal(t, "Old_age", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, false, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 5:
 			require.Equal(t, "Reallocated_Sector_Ct", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -81,8 +81,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 36, int(thr.Thresholds[5]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 9:
 			require.Equal(t, "Power_On_Hours", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -90,8 +90,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 1, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[9]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 12:
 			require.Equal(t, "Power_Cycle_Count", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -99,8 +99,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[12]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		case 190:
 			require.Equal(t, "Airflow_Temperature_Cel", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -113,8 +113,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 31, high)
 			require.Equal(t, 0, counter) // not supported at this drive
 			require.Equal(t, 50, int(thr.Thresholds[190]))
-			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
-			require.Equal(t, "Always", a.AttributeFlagsOnline())
+			require.Equal(t, true, a.AttributeFlagsPrefailure())
+			require.Equal(t, true, a.AttributeFlagsOnline())
 		}
 	}
 

--- a/examples/sata_linux_test.go
+++ b/examples/sata_linux_test.go
@@ -54,6 +54,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 6, int(thr.Thresholds[1]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 3:
 			require.Equal(t, "Spin_Up_Time", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -61,6 +63,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 16, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[3]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 4:
 			require.Equal(t, "Start_Stop_Count", a.Name)
 			require.Equal(t, 0x0002, int(a.Flags))
@@ -68,6 +72,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 100, int(a.ValueRaw))
 			require.Equal(t, 20, int(thr.Thresholds[4]))
+			require.Equal(t, "Old_age", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 5:
 			require.Equal(t, "Reallocated_Sector_Ct", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -75,6 +81,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 36, int(thr.Thresholds[5]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 9:
 			require.Equal(t, "Power_On_Hours", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -82,6 +90,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 1, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[9]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 12:
 			require.Equal(t, "Power_Cycle_Count", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -89,6 +99,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[12]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		case 190:
 			require.Equal(t, "Airflow_Temperature_Cel", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -101,6 +113,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 31, high)
 			require.Equal(t, 0, counter) // not supported at this drive
 			require.Equal(t, 50, int(thr.Thresholds[190]))
+			require.Equal(t, "Pre-fail", a.AttributeFlagsPrefailure())
+			require.Equal(t, "Always", a.AttributeFlagsOnline())
 		}
 	}
 

--- a/examples/sata_linux_test.go
+++ b/examples/sata_linux_test.go
@@ -54,8 +54,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 6, int(thr.Thresholds[1]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 3:
 			require.Equal(t, "Spin_Up_Time", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -63,8 +63,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 16, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[3]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 4:
 			require.Equal(t, "Start_Stop_Count", a.Name)
 			require.Equal(t, 0x0002, int(a.Flags))
@@ -72,8 +72,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 100, int(a.ValueRaw))
 			require.Equal(t, 20, int(thr.Thresholds[4]))
-			require.Equal(t, false, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.Zero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 5:
 			require.Equal(t, "Reallocated_Sector_Ct", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -81,8 +81,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 36, int(thr.Thresholds[5]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 9:
 			require.Equal(t, "Power_On_Hours", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -90,8 +90,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 1, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[9]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 12:
 			require.Equal(t, "Power_Cycle_Count", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -99,8 +99,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 100, int(a.Worst))
 			require.Equal(t, 0, int(a.ValueRaw))
 			require.Equal(t, 0, int(thr.Thresholds[12]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		case 190:
 			require.Equal(t, "Airflow_Temperature_Cel", a.Name)
 			require.Equal(t, 0x0003, int(a.Flags))
@@ -113,8 +113,8 @@ func TestSata(t *testing.T) {
 			require.Equal(t, 31, high)
 			require.Equal(t, 0, counter) // not supported at this drive
 			require.Equal(t, 50, int(thr.Thresholds[190]))
-			require.Equal(t, true, a.AttributeFlagsPrefailure())
-			require.Equal(t, true, a.AttributeFlagsOnline())
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagPrefailure)
+			require.NotZero(t, a.Flags&smart.AtaAttributeFlagOnline)
 		}
 	}
 

--- a/sata.go
+++ b/sata.go
@@ -671,18 +671,18 @@ func checkTempRange(t int8, t1 int8, t2 int8, lo *int8, hi *int8) bool {
 	return false
 }
 
-func (a AtaSmartAttr) AttributeFlagsPrefailure() string {
+func (a AtaSmartAttr) AttributeFlagsPrefailure() bool {
 	if a.Flags&ATTRIBUTE_FLAGS_PREFAILURE != 0 {
-		return "Pre-fail"
+		return true
 	}
-	return "Old_age"
+	return false
 }
 
-func (a AtaSmartAttr) AttributeFlagsOnline() string {
+func (a AtaSmartAttr) AttributeFlagsOnline() bool {
 	if a.Flags&ATTRIBUTE_FLAGS_ONLINE != 0 {
-		return "Always"
+		return true
 	}
-	return "Offline"
+	return false
 }
 
 type AtaSmartPage struct {

--- a/sata.go
+++ b/sata.go
@@ -23,6 +23,9 @@ const (
 	_SMART_READ_THRESHOLDS = 0xd1
 	_SMART_READ_LOG        = 0xd5
 	_SMART_RETURN_STATUS   = 0xda
+
+	ATTRIBUTE_FLAGS_PREFAILURE = 0x01 // 0: Prefailure bit
+	ATTRIBUTE_FLAGS_ONLINE     = 0x02 // 1: Online bit
 )
 
 // AtaIdentifyDevice ATA IDENTIFY DEVICE struct. ATA8-ACS defines this as a page of 16-bit words.
@@ -666,6 +669,20 @@ func checkTempRange(t int8, t1 int8, t2 int8, lo *int8, hi *int8) bool {
 		return true
 	}
 	return false
+}
+
+func (a AtaSmartAttr) AttributeFlagsPrefailure() string {
+	if a.Flags&ATTRIBUTE_FLAGS_PREFAILURE != 0 {
+		return "Pre-fail"
+	}
+	return "Old_age"
+}
+
+func (a AtaSmartAttr) AttributeFlagsOnline() string {
+	if a.Flags&ATTRIBUTE_FLAGS_ONLINE != 0 {
+		return "Always"
+	}
+	return "Offline"
 }
 
 type AtaSmartPage struct {

--- a/sata.go
+++ b/sata.go
@@ -23,9 +23,6 @@ const (
 	_SMART_READ_THRESHOLDS = 0xd1
 	_SMART_READ_LOG        = 0xd5
 	_SMART_RETURN_STATUS   = 0xda
-
-	ATTRIBUTE_FLAGS_PREFAILURE = 0x01 // 0: Prefailure bit
-	ATTRIBUTE_FLAGS_ONLINE     = 0x02 // 1: Online bit
 )
 
 // AtaIdentifyDevice ATA IDENTIFY DEVICE struct. ATA8-ACS defines this as a page of 16-bit words.
@@ -559,6 +556,13 @@ func findMatchingDbRecord(model, firmware string) (*ataDeviceInfo, error) {
 	return nil, nil
 }
 
+const (
+	// Prefailure bit. If the flag is 0 it corresponds to "Old_age" value, "Pre-fail" otherwise
+	AtaAttributeFlagPrefailure = 1 << 0
+	// Online bit. If the flag is 0 it corresponds to "Offline" value, "Always" otherwise
+	AtaAttributeFlagOnline = 1 << 1
+)
+
 type AtaSmartAttr struct {
 	Id          uint8
 	Flags       uint16
@@ -666,20 +670,6 @@ func checkTempRange(t int8, t1 int8, t2 int8, lo *int8, hi *int8) bool {
 	if -60 <= t1 && t1 <= t && t <= t2 && t2 <= 120 && !(t1 == -1 && t2 <= 0) {
 		*lo = t1
 		*hi = t2
-		return true
-	}
-	return false
-}
-
-func (a AtaSmartAttr) AttributeFlagsPrefailure() bool {
-	if a.Flags&ATTRIBUTE_FLAGS_PREFAILURE != 0 {
-		return true
-	}
-	return false
-}
-
-func (a AtaSmartAttr) AttributeFlagsOnline() bool {
-	if a.Flags&ATTRIBUTE_FLAGS_ONLINE != 0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
Functionality to provide the same output as `smartctl` does for prefailure (**TYPE**) and online (**UPDATED**) bits:
```
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x000b   100   100   050    Pre-fail  Always       -       0
  2 Throughput_Performance  0x0005   100   100   050    Pre-fail  Offline      -       0
  4 Start_Stop_Count        0x0032   100   100   000    Old_age   Always       -       192
```