### PR TITLE
fix: guard NVMe probe, allow SCSI fallback for SATA devices

### DIFF
--- a/scsi_linux.go
+++ b/scsi_linux.go
@@ -35,11 +35,6 @@ func OpenScsi(name string) (*ScsiDevice, error) {
 		return nil, fmt.Errorf("not a direct access block device")
 	}
 
-	if bytes.Equal(i.VendorIdent[:], []byte(_SATA_IDENT)) {
-		unix.Close(fd)
-		return nil, fmt.Errorf("it is SATA device")
-	}
-
 	return &scsi, nil
 }
 

--- a/smart.go
+++ b/smart.go
@@ -3,6 +3,7 @@ package smart
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ErrOSUnsupported is returned on unsupported operating systems.
@@ -31,14 +32,24 @@ type Device interface {
 }
 
 func Open(path string) (Device, error) {
-	n, nvmeErr := OpenNVMe(path)
-	if nvmeErr == nil {
-		_, _, err := n.Identify()
+	var nvmeErr error
+
+	// Only probe NVMe for paths that look like NVMe devices (/dev/nvme*).
+	// Sending NVMe admin ioctls to USB block devices permanently breaks
+	// the UAS transport on some bridges (e.g. Realtek RTL9201B), causing
+	// all subsequent SCSI commands to fail with DID_ERROR.
+	if strings.Contains(path, "/nvme") {
+		n, err := OpenNVMe(path)
 		if err == nil {
-			return n, nil
+			_, _, idErr := n.Identify()
+			if idErr == nil {
+				return n, nil
+			}
+			n.Close()
+			nvmeErr = fmt.Errorf("nvme identify: %w", idErr)
+		} else {
+			nvmeErr = err
 		}
-		n.Close()
-		nvmeErr = fmt.Errorf("nvme identify: %w", err)
 	}
 
 	a, sataErr := OpenSata(path)
@@ -51,5 +62,8 @@ func Open(path string) (Device, error) {
 		return s, nil
 	}
 
-	return nil, errors.Join(nvmeErr, sataErr, scsiErr)
+	if nvmeErr != nil {
+		return nil, errors.Join(nvmeErr, sataErr, scsiErr)
+	}
+	return nil, errors.Join(sataErr, scsiErr)
 }


### PR DESCRIPTION
## Summary

Two fixes for device probing in `Open()` and `OpenScsi()`:

**1. Guard NVMe ioctl probe to non-NVMe paths only**

`Open()` unconditionally sends NVMe admin ioctls to every block device path. On USB mass storage devices (especially those behind UAS bridges like the Realtek RTL9201B), these ioctls permanently break the UAS transport — all subsequent SCSI commands fail with `DID_ERROR` until the device is replugged.

This is likely the root cause of #17 (kernel panic when flash drive plugged in via booster, which uses this library).

The fix restricts NVMe probing to paths containing `/nvme` (i.e., `/dev/nvme*`), which is the standard Linux NVMe device naming convention.

**2. Remove SATA vendor check in `OpenScsi()`**

`OpenScsi()` rejects devices whose SCSI INQUIRY vendor string matches `_SATA_IDENT`. This prevents SCSI fallback when SAT-layer probing in `OpenSata()` fails, even though the device may still respond to SCSI commands (e.g., for temperature or health data via MODE SENSE).

Since `OpenSata()` is always tried first, the SCSI layer being more permissive does not cause duplicate handling.

## Testing

- Tested on SATA SSD (`/dev/sda`) and USB-SATA bridge (`/dev/sdb`) — both correctly skip NVMe probe and fall through to SATA/SCSI
- NVMe device (`/dev/nvme0`) still correctly identified via NVMe path
- USB devices with UAS bridges no longer break after `Open()` is called

Closes #17