### PR TITLE
Add ReadDeviceStatistics() for SATA devices (ATA Device Statistics, GP Log 0x04)

### DIFF
--- a/device_statistics_test.go
+++ b/device_statistics_test.go
@@ -1,0 +1,49 @@
+package smart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtaDeviceStatistics(t *testing.T) {
+	t.Parallel()
+
+	// Solid State Device Statistics page (07h), "Percentage Used Endurance
+	// Indicator" at offset 008h.
+	const ssdEndurance = 0x07*512 + 0x008
+
+	buf := make([]byte, 8*512)
+	buf[ssdEndurance] = 51     // value (low byte)
+	buf[ssdEndurance+7] = 0xC0 // flags: supported | valid
+	s := &AtaDeviceStatistics{raw: buf}
+
+	pct, ok := s.PercentUsedEndurance()
+	require.True(t, ok)
+	require.Equal(t, uint8(51), pct)
+
+	v, ok := s.Get(0x07, 0x008)
+	require.True(t, ok)
+	require.Equal(t, uint64(51), v)
+
+	// Multi-byte value: the flags byte must be stripped from the result.
+	const general = 0x01*512 + 0x010
+	gen := make([]byte, 8*512)
+	gen[general] = 0x34
+	gen[general+1] = 0x12
+	gen[general+7] = 0xC0 // supported | valid
+	mv, ok := (&AtaDeviceStatistics{raw: gen}).Get(0x01, 0x010)
+	require.True(t, ok)
+	require.Equal(t, uint64(0x1234), mv)
+
+	// Supported but not valid -> not present.
+	inv := make([]byte, 8*512)
+	inv[ssdEndurance] = 51
+	inv[ssdEndurance+7] = 0x80 // supported only
+	_, ok = (&AtaDeviceStatistics{raw: inv}).PercentUsedEndurance()
+	require.False(t, ok)
+
+	// Out of range -> not present.
+	_, ok = (&AtaDeviceStatistics{raw: make([]byte, 100)}).Get(0x07, 0x008)
+	require.False(t, ok)
+}

--- a/device_statistics_test.go
+++ b/device_statistics_test.go
@@ -11,18 +11,12 @@ func TestAtaDeviceStatistics(t *testing.T) {
 
 	// Solid State Device Statistics page (07h), "Percentage Used Endurance
 	// Indicator" at offset 008h.
-	const ssdEndurance = 0x07*512 + 0x008
-
 	buf := make([]byte, 8*512)
-	buf[ssdEndurance] = 51     // value (low byte)
-	buf[ssdEndurance+7] = 0xC0 // flags: supported | valid
+	buf[StatPercentageUsedEndurance] = 51     // value (low byte)
+	buf[StatPercentageUsedEndurance+7] = 0xC0 // flags: supported | valid
 	s := &AtaDeviceStatistics{raw: buf}
 
-	pct, ok := s.PercentUsedEndurance()
-	require.True(t, ok)
-	require.Equal(t, uint8(51), pct)
-
-	v, ok := s.Get(0x07, 0x008)
+	v, ok := s.Get(StatPercentageUsedEndurance)
 	require.True(t, ok)
 	require.Equal(t, uint64(51), v)
 
@@ -32,18 +26,18 @@ func TestAtaDeviceStatistics(t *testing.T) {
 	gen[general] = 0x34
 	gen[general+1] = 0x12
 	gen[general+7] = 0xC0 // supported | valid
-	mv, ok := (&AtaDeviceStatistics{raw: gen}).Get(0x01, 0x010)
+	mv, ok := (&AtaDeviceStatistics{raw: gen}).Get(general)
 	require.True(t, ok)
 	require.Equal(t, uint64(0x1234), mv)
 
 	// Supported but not valid -> not present.
 	inv := make([]byte, 8*512)
-	inv[ssdEndurance] = 51
-	inv[ssdEndurance+7] = 0x80 // supported only
-	_, ok = (&AtaDeviceStatistics{raw: inv}).PercentUsedEndurance()
+	inv[StatPercentageUsedEndurance] = 51
+	inv[StatPercentageUsedEndurance+7] = 0x80 // supported only
+	_, ok = (&AtaDeviceStatistics{raw: inv}).Get(StatPercentageUsedEndurance)
 	require.False(t, ok)
 
 	// Out of range -> not present.
-	_, ok = (&AtaDeviceStatistics{raw: make([]byte, 100)}).Get(0x07, 0x008)
+	_, ok = (&AtaDeviceStatistics{raw: make([]byte, 100)}).Get(StatPercentageUsedEndurance)
 	require.False(t, ok)
 }

--- a/device_statistics_test.go
+++ b/device_statistics_test.go
@@ -12,11 +12,11 @@ func TestAtaDeviceStatistics(t *testing.T) {
 	// Solid State Device Statistics page (07h), "Percentage Used Endurance
 	// Indicator" at offset 008h.
 	buf := make([]byte, 8*512)
-	buf[StatPercentageUsedEndurance] = 51     // value (low byte)
-	buf[StatPercentageUsedEndurance+7] = 0xC0 // flags: supported | valid
+	buf[AtaStatPercentageUsedEndurance] = 51     // value (low byte)
+	buf[AtaStatPercentageUsedEndurance+7] = 0xC0 // flags: supported | valid
 	s := &AtaDeviceStatistics{raw: buf}
 
-	v, ok := s.Get(StatPercentageUsedEndurance)
+	v, ok := s.Get(AtaStatPercentageUsedEndurance)
 	require.True(t, ok)
 	require.Equal(t, uint64(51), v)
 
@@ -32,12 +32,12 @@ func TestAtaDeviceStatistics(t *testing.T) {
 
 	// Supported but not valid -> not present.
 	inv := make([]byte, 8*512)
-	inv[StatPercentageUsedEndurance] = 51
-	inv[StatPercentageUsedEndurance+7] = 0x80 // supported only
-	_, ok = (&AtaDeviceStatistics{raw: inv}).Get(StatPercentageUsedEndurance)
+	inv[AtaStatPercentageUsedEndurance] = 51
+	inv[AtaStatPercentageUsedEndurance+7] = 0x80 // supported only
+	_, ok = (&AtaDeviceStatistics{raw: inv}).Get(AtaStatPercentageUsedEndurance)
 	require.False(t, ok)
 
 	// Out of range -> not present.
-	_, ok = (&AtaDeviceStatistics{raw: make([]byte, 100)}).Get(StatPercentageUsedEndurance)
+	_, ok = (&AtaDeviceStatistics{raw: make([]byte, 100)}).Get(AtaStatPercentageUsedEndurance)
 	require.False(t, ok)
 }

--- a/sata.go
+++ b/sata.go
@@ -2,6 +2,7 @@ package smart
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"maps"
 	"regexp"
@@ -512,6 +513,43 @@ type AtaSmartLogDirectory struct {
 		NumPages byte
 		_        byte // Reserved
 	}
+}
+
+// AtaDeviceStatistics is a parsed view of the ATA Device Statistics log
+// (General Purpose Log 04h, read via SataDevice.ReadDeviceStatistics). The log
+// is organized into 512-byte pages; each statistic is an 8-byte little-endian
+// field identified by its page number and byte offset within the page. The most
+// significant byte holds the field flags (bit 7 "supported", bit 6 "valid"); the
+// low 7 bytes hold the value. See ACS-4 section 9.5.
+type AtaDeviceStatistics struct {
+	raw []byte // the device statistics log payload (8 sectors)
+}
+
+// Get returns the value of the device statistic at the given page number and
+// byte offset within that page, together with whether it is present. ok is false
+// when the field is out of range, unsupported, or marked invalid by the device.
+// For example, Get(0x07, 0x008) reads the Solid State Device Statistics
+// "Percentage Used Endurance Indicator".
+func (s *AtaDeviceStatistics) Get(page uint8, offset uint16) (value uint64, ok bool) {
+	start := int(page)*512 + int(offset)
+	if start < 0 || start+8 > len(s.raw) {
+		return 0, false
+	}
+	field := binary.LittleEndian.Uint64(s.raw[start : start+8])
+	const flagSupported, flagValid = 1 << 63, 1 << 62 // most-significant byte
+	if field&flagSupported == 0 || field&flagValid == 0 {
+		return 0, false
+	}
+	return field & (1<<56 - 1), true // low 7 bytes
+}
+
+// PercentUsedEndurance returns the Solid State Device Statistics "Percentage Used
+// Endurance Indicator" (page 07h, offset 008h): the approximate percentage of the
+// device's rated write endurance that has been consumed (0 = new; the value may
+// exceed 100). ok is false if the device does not report it.
+func (s *AtaDeviceStatistics) PercentUsedEndurance() (percent uint8, ok bool) {
+	v, ok := s.Get(0x07, 0x008)
+	return uint8(v), ok
 }
 
 // SMART log address 01h

--- a/sata.go
+++ b/sata.go
@@ -516,40 +516,42 @@ type AtaSmartLogDirectory struct {
 }
 
 // AtaDeviceStatistics is a parsed view of the ATA Device Statistics log
-// (General Purpose Log 04h, read via SataDevice.ReadDeviceStatistics). The log
-// is organized into 512-byte pages; each statistic is an 8-byte little-endian
-// field identified by its page number and byte offset within the page. The most
-// significant byte holds the field flags (bit 7 "supported", bit 6 "valid"); the
-// low 7 bytes hold the value. See ACS-4 section 9.5.
+// (General Purpose Log 04h, read via SataDevice.ReadStatistics). The log is
+// organized into 512-byte pages; each statistic is an 8-byte little-endian field
+// addressed by its byte offset from the start of the log (the page number times
+// 512, plus the field's offset within the page). The most significant byte holds
+// the field flags (bit 7 "supported", bit 6 "valid"); the low 7 bytes hold the
+// value. See the Device Statistics log in ACS-4 (T13/BSR INCITS 529) 9.5; the
+// same content is in the freely available ACS-3 working draft (T13/2161) Annex A.5.
 type AtaDeviceStatistics struct {
 	raw []byte // the device statistics log payload (8 sectors)
 }
 
-// Get returns the value of the device statistic at the given page number and
-// byte offset within that page, together with whether it is present. ok is false
-// when the field is out of range, unsupported, or marked invalid by the device.
-// For example, Get(0x07, 0x008) reads the Solid State Device Statistics
-// "Percentage Used Endurance Indicator".
-func (s *AtaDeviceStatistics) Get(page uint8, offset uint16) (value uint64, ok bool) {
-	start := int(page)*512 + int(offset)
-	if start < 0 || start+8 > len(s.raw) {
+// Device statistic offsets, expressed as the byte offset from the start of the
+// Device Statistics log (the page number times 512, plus the field's offset
+// within the page), for use with AtaDeviceStatistics.Get.
+const (
+	// StatPercentageUsedEndurance is the Solid State Device Statistics
+	// "Percentage Used Endurance Indicator" (page 07h, offset 008h; ACS-4
+	// 9.5.7.3): an approximate percentage of the device's rated write endurance
+	// that has been consumed (0 = new; the value may exceed 100).
+	StatPercentageUsedEndurance = 0x07*512 + 0x008
+)
+
+// Get returns the value of the device statistic at the given byte offset from
+// the start of the log (for example StatPercentageUsedEndurance), together with
+// whether it is present. ok is false when the offset is out of range, or the
+// field is unsupported or marked invalid by the device.
+func (s *AtaDeviceStatistics) Get(offset int) (value uint64, ok bool) {
+	if offset < 0 || offset+8 > len(s.raw) {
 		return 0, false
 	}
-	field := binary.LittleEndian.Uint64(s.raw[start : start+8])
+	field := binary.LittleEndian.Uint64(s.raw[offset : offset+8])
 	const flagSupported, flagValid = 1 << 63, 1 << 62 // most-significant byte
 	if field&flagSupported == 0 || field&flagValid == 0 {
 		return 0, false
 	}
 	return field & (1<<56 - 1), true // low 7 bytes
-}
-
-// PercentUsedEndurance returns the Solid State Device Statistics "Percentage Used
-// Endurance Indicator" (page 07h, offset 008h): the approximate percentage of the
-// device's rated write endurance that has been consumed (0 = new; the value may
-// exceed 100). ok is false if the device does not report it.
-func (s *AtaDeviceStatistics) PercentUsedEndurance() (percent uint8, ok bool) {
-	v, ok := s.Get(0x07, 0x008)
-	return uint8(v), ok
 }
 
 // SMART log address 01h

--- a/sata.go
+++ b/sata.go
@@ -531,15 +531,15 @@ type AtaDeviceStatistics struct {
 // Device Statistics log (the page number times 512, plus the field's offset
 // within the page), for use with AtaDeviceStatistics.Get.
 const (
-	// StatPercentageUsedEndurance is the Solid State Device Statistics
+	// AtaStatPercentageUsedEndurance is the Solid State Device Statistics
 	// "Percentage Used Endurance Indicator" (page 07h, offset 008h; ACS-4
 	// 9.5.7.3): an approximate percentage of the device's rated write endurance
 	// that has been consumed (0 = new; the value may exceed 100).
-	StatPercentageUsedEndurance = 0x07*512 + 0x008
+	AtaStatPercentageUsedEndurance = 0x07*512 + 0x008
 )
 
 // Get returns the value of the device statistic at the given byte offset from
-// the start of the log (for example StatPercentageUsedEndurance), together with
+// the start of the log (for example AtaStatPercentageUsedEndurance), together with
 // whether it is present. ok is false when the offset is out of range, or the
 // field is unsupported or marked invalid by the device.
 func (s *AtaDeviceStatistics) Get(offset int) (value uint64, ok bool) {

--- a/sata_linux.go
+++ b/sata_linux.go
@@ -210,11 +210,11 @@ func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 	return &page, nil
 }
 
-// ReadDeviceStatistics reads the ATA Device Statistics log (GP Log 0x04) and
-// returns its raw multi-sector payload (8 sectors = 4096 bytes). The caller
-// parses the desired statistic, e.g. the Solid State Device Statistics page
-// (page 0x07) "Percentage Used Endurance Indicator" at page offset 0x008.
-func (d *SataDevice) ReadDeviceStatistics() ([]byte, error) {
+// ReadDeviceStatistics reads and parses the ATA Device Statistics log (General
+// Purpose Log 04h). Individual statistics are read from the returned value via
+// AtaDeviceStatistics.Get (or a convenience accessor such as PercentUsedEndurance),
+// honoring each field's supported/valid flags.
+func (d *SataDevice) ReadDeviceStatistics() (*AtaDeviceStatistics, error) {
 	const sectors = 8
 	respBuf := make([]byte, 512*sectors)
 
@@ -231,5 +231,5 @@ func (d *SataDevice) ReadDeviceStatistics() ([]byte, error) {
 	if err := scsiSendCdb(d.fd, cdb[:], respBuf); err != nil {
 		return nil, fmt.Errorf("scsiSendCdb SMART READ LOG (device statistics): %w", err)
 	}
-	return respBuf, nil
+	return &AtaDeviceStatistics{raw: respBuf}, nil
 }

--- a/sata_linux.go
+++ b/sata_linux.go
@@ -210,11 +210,10 @@ func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 	return &page, nil
 }
 
-// ReadDeviceStatistics reads and parses the ATA Device Statistics log (General
+// ReadStatistics reads and parses the ATA Device Statistics log (General
 // Purpose Log 04h). Individual statistics are read from the returned value via
-// AtaDeviceStatistics.Get (or a convenience accessor such as PercentUsedEndurance),
-// honoring each field's supported/valid flags.
-func (d *SataDevice) ReadDeviceStatistics() (*AtaDeviceStatistics, error) {
+// AtaDeviceStatistics.Get, honoring each field's supported/valid flags.
+func (d *SataDevice) ReadStatistics() (*AtaDeviceStatistics, error) {
 	const sectors = 8
 	respBuf := make([]byte, 512*sectors)
 

--- a/sata_linux.go
+++ b/sata_linux.go
@@ -209,3 +209,27 @@ func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 
 	return &page, nil
 }
+
+// ReadDeviceStatistics reads the ATA Device Statistics log (GP Log 0x04) and
+// returns its raw multi-sector payload (8 sectors = 4096 bytes). The caller
+// parses the desired statistic, e.g. the Solid State Device Statistics page
+// (page 0x07) "Percentage Used Endurance Indicator" at page offset 0x008.
+func (d *SataDevice) ReadDeviceStatistics() ([]byte, error) {
+	const sectors = 8
+	respBuf := make([]byte, 512*sectors)
+
+	cdb := cdb16{_SCSI_ATA_PASSTHRU_16}
+	cdb[1] = 0x08            // ATA protocol (4 << 1, PIO data-in)
+	cdb[2] = 0x0e            // BYT_BLOK = 1, T_LENGTH = 2, T_DIR = 1
+	cdb[4] = _SMART_READ_LOG // feature LSB
+	cdb[6] = sectors         // sector count: transfer 8 sectors (4096 bytes)
+	cdb[8] = 0x04            // log address: Device Statistics log
+	cdb[10] = 0x4f           // LBA mid: SMART signature byte 0x4F
+	cdb[12] = 0xc2           // LBA high: SMART signature byte 0xC2
+	cdb[14] = _ATA_SMART     // command
+
+	if err := scsiSendCdb(d.fd, cdb[:], respBuf); err != nil {
+		return nil, fmt.Errorf("scsiSendCdb SMART READ LOG (device statistics): %w", err)
+	}
+	return respBuf, nil
+}

--- a/sata_other.go
+++ b/sata_other.go
@@ -37,3 +37,7 @@ func (d *SataDevice) ReadSMARTSelfTestLog() (*AtaSmartSelfTestLog, error) {
 func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 	return nil, ErrOSUnsupported
 }
+
+func (d *SataDevice) ReadDeviceStatistics() ([]byte, error) {
+	return nil, ErrOSUnsupported
+}

--- a/sata_other.go
+++ b/sata_other.go
@@ -38,6 +38,6 @@ func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 	return nil, ErrOSUnsupported
 }
 
-func (d *SataDevice) ReadDeviceStatistics() ([]byte, error) {
+func (d *SataDevice) ReadDeviceStatistics() (*AtaDeviceStatistics, error) {
 	return nil, ErrOSUnsupported
 }

--- a/sata_other.go
+++ b/sata_other.go
@@ -38,6 +38,6 @@ func (d *SataDevice) readSMARTThresholds() (*AtaSmartThresholdsPageRaw, error) {
 	return nil, ErrOSUnsupported
 }
 
-func (d *SataDevice) ReadDeviceStatistics() (*AtaDeviceStatistics, error) {
+func (d *SataDevice) ReadStatistics() (*AtaDeviceStatistics, error) {
 	return nil, ErrOSUnsupported
 }


### PR DESCRIPTION
## Add `ReadDeviceStatistics()` for SATA devices

Adds `(*SataDevice).ReadDeviceStatistics()`, which reads the ATA **Device Statistics** log (GP Log `0x04`) and returns its raw multi-sector payload.

### Why

The Device Statistics log carries standardized counters that are not exposed through the vendor SMART attribute table. The most useful one for SSD health is the **Percentage Used Endurance Indicator** (Solid State Device Statistics page `0x07`, offset `0x008`) — a spec-defined wear metric, effectively the ATA analog of NVMe's "Percentage Used". Because it has a single ACS-defined meaning, it's reliable across vendors, unlike the wear-related vendor attribute IDs (e.g. attr `233` is `Media_Wearout_Indicator` on Intel but a raw write counter on some Kingston drives).

There's currently no way to reach this log through the public API.

### What it does

- Issues `SMART READ LOG` for log address `0x04`, transferring all 8 sectors (4096 bytes), reusing the existing `scsiSendCdb` / `cdb16` plumbing — the CDB is identical to `readSMARTLog` apart from the log address and an 8-sector count.
- Returns the raw bytes so the caller can parse whichever statistic it needs; this keeps the library unopinionated about page layout (consistent with how `ReadSMARTLogDirectory` exposes its buffer).
- Adds the matching `ErrOSUnsupported` stub in `sata_other.go`, mirroring the other `SataDevice` methods so non-Linux builds are unaffected.

### Notes

- Scope is intentionally minimal (raw bytes, one new method). I'm happy to follow up with a typed `DeviceStatistics` parser if you'd prefer a higher-level API.
- No changes outside `sata_linux.go` / `sata_other.go`.

Example caller (parsing the SSD endurance indicator):

```go
buf, err := dev.ReadDeviceStatistics()
if err == nil && len(buf) >= 0x07*512+0x010 {
    stat := buf[0x07*512+0x008:] // SSD page, "Percentage Used Endurance Indicator"
    if stat[7]&0x40 != 0 {       // ACS statistic flags: value valid
        percentUsed := int(stat[0])
        _ = percentUsed
    }
}
```
