### PR TITLE
Add named offset constants for common Device Statistics

### DIFF
--- a/device_statistics_test.go
+++ b/device_statistics_test.go
@@ -21,12 +21,11 @@ func TestAtaDeviceStatistics(t *testing.T) {
 	require.Equal(t, uint64(51), v)
 
 	// Multi-byte value: the flags byte must be stripped from the result.
-	const general = 0x01*512 + 0x010
 	gen := make([]byte, 8*512)
-	gen[general] = 0x34
-	gen[general+1] = 0x12
-	gen[general+7] = 0xC0 // supported | valid
-	mv, ok := (&AtaDeviceStatistics{raw: gen}).Get(general)
+	gen[AtaStatPowerOnHours] = 0x34
+	gen[AtaStatPowerOnHours+1] = 0x12
+	gen[AtaStatPowerOnHours+7] = 0xC0 // supported | valid
+	mv, ok := (&AtaDeviceStatistics{raw: gen}).Get(AtaStatPowerOnHours)
 	require.True(t, ok)
 	require.Equal(t, uint64(0x1234), mv)
 

--- a/sata.go
+++ b/sata.go
@@ -531,6 +531,42 @@ type AtaDeviceStatistics struct {
 // Device Statistics log (the page number times 512, plus the field's offset
 // within the page), for use with AtaDeviceStatistics.Get.
 const (
+	// AtaStatLifetimePowerOnResets is the General Statistics "Lifetime Power-On
+	// Resets" (page 01h, offset 008h): the number of power-on events over the
+	// life of the device.
+	AtaStatLifetimePowerOnResets = 0x01*512 + 0x008
+
+	// AtaStatPowerOnHours is the General Statistics "Power-on Hours"
+	// (page 01h, offset 010h): the number of power-on hours over the life of
+	// the device.
+	AtaStatPowerOnHours = 0x01*512 + 0x010
+
+	// AtaStatLogicalSectorsWritten is the General Statistics "Logical Sectors
+	// Written" (page 01h, offset 018h): the number of logical sectors written
+	// over the life of the device.
+	AtaStatLogicalSectorsWritten = 0x01*512 + 0x018
+
+	// AtaStatLogicalSectorsRead is the General Statistics "Logical Sectors
+	// Read" (page 01h, offset 028h): the number of logical sectors read over
+	// the life of the device.
+	AtaStatLogicalSectorsRead = 0x01*512 + 0x028
+
+	// AtaStatReportedUncorrectableErrors is the General Errors Statistics
+	// "Number of Reported Uncorrectable Errors" (page 04h, offset 008h): the
+	// number of errors reported as uncorrectable over the life of the device.
+	AtaStatReportedUncorrectableErrors = 0x04*512 + 0x008
+
+	// AtaStatCurrentTemperature is the Temperature Statistics "Current
+	// Temperature" (page 05h, offset 008h) in degrees Celsius. Unlike the
+	// counters above, this statistic is signed: convert the low byte of the
+	// returned value with int8(uint8(v)) instead of using it as a uint64.
+	AtaStatCurrentTemperature = 0x05*512 + 0x008
+
+	// AtaStatInterfaceCRCErrors is the Transport Statistics "Number of
+	// Interface CRC Errors" (page 06h, offset 018h): the number of interface
+	// CRC errors detected over the life of the device.
+	AtaStatInterfaceCRCErrors = 0x06*512 + 0x018
+
 	// AtaStatPercentageUsedEndurance is the Solid State Device Statistics
 	// "Percentage Used Endurance Indicator" (page 07h, offset 008h; ACS-4
 	// 9.5.7.3): an approximate percentage of the device's rated write endurance


### PR DESCRIPTION
Follow-up to #22, where you asked about covering more statistics - this adds named `AtaStat*` offset constants for the most commonly consumed Device Statistics, keeping the same shape as `AtaStatPercentageUsedEndurance`:

- `AtaStatLifetimePowerOnResets`, `AtaStatPowerOnHours`, `AtaStatLogicalSectorsWritten`, `AtaStatLogicalSectorsRead` (General Statistics, page 01h)
- `AtaStatReportedUncorrectableErrors` (General Errors Statistics, page 04h)
- `AtaStatCurrentTemperature` (Temperature Statistics, page 05h) - doc comment notes this one is signed, so callers should convert the low byte via `int8` rather than use the raw `uint64`
- `AtaStatInterfaceCRCErrors` (Transport Statistics, page 06h)

Offsets were verified against the ACS-3 working draft (T13/2161, Annex A.5) and cross-checked against live SATA SSDs (`smartctl -l devstat` on Intel DC and generic drives). I deliberately left out the Rotating Media Statistics page (03h) since I had no spinning drive to verify against - happy to add those too if you'd like.

The existing multi-byte test case in `device_statistics_test.go` now uses `AtaStatPowerOnHours` instead of its magic `0x01*512 + 0x010` offset, so one of the new constants is exercised by the existing test.

No behavior changes - constants and doc comments only (plus the test cleanup).