### PR TITLE
fix: open Linux device descriptors with `O_CLOEXEC`

### DIFF
--- a/cloexec_linux_test.go
+++ b/cloexec_linux_test.go
@@ -1,0 +1,32 @@
+package smart
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestOpenSetsFlags verifies that device descriptors are opened read-only and
+// with the O_CLOEXEC flag, so they are not leaked to child processes across
+// execve.
+func TestOpenSetsFlags(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "fakedev")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+	dev, err := OpenNVMe(path)
+	require.NoError(t, err)
+	defer dev.Close()
+
+	fdFlags, err := unix.FcntlInt(uintptr(dev.fd), unix.F_GETFD, 0)
+	require.NoError(t, err)
+	require.NotZero(t, fdFlags&unix.FD_CLOEXEC, "device fd must have FD_CLOEXEC set")
+
+	statusFlags, err := unix.FcntlInt(uintptr(dev.fd), unix.F_GETFL, 0)
+	require.NoError(t, err)
+	require.Equal(t, unix.O_RDONLY, statusFlags&unix.O_ACCMODE, "device fd must be read-only")
+}

--- a/examples/cloexec_linux_test.go
+++ b/examples/cloexec_linux_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// requireFdFlag locates the process's open descriptor(s) for path and asserts
+// that (flags & mask) == want, where flags are read via fcntl(fd, cmd).
+//
+// It works for both fcntl flag namespaces:
+//   - descriptor flags:  cmd = unix.F_GETFD, e.g. FD_CLOEXEC
+//   - access mode:       cmd = unix.F_GETFL, mask = O_ACCMODE, want = O_RDONLY
+//     (matched by value, since O_RDONLY is 0 and can't be tested as a bit)
+//
+// The smart.go device types keep their fd unexported, so we find it by scanning
+// /proc/self/fd for the symlink that resolves to path.
+func requireFdFlag(t *testing.T, path string, cmd, mask, want int, desc string) {
+	t.Helper()
+
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", e.Name()))
+		if err != nil || target != path {
+			continue
+		}
+
+		fd, err := strconv.Atoi(e.Name())
+		require.NoError(t, err)
+
+		flags, err := unix.FcntlInt(uintptr(fd), cmd, 0)
+		require.NoError(t, err)
+		require.Equalf(t, want, flags&mask, "fd for %s: expected %s", path, desc)
+		found = true
+	}
+
+	require.Truef(t, found, "no open fd found for %s", path)
+}
+
+// requireCloexec asserts the device fd for path has close-on-exec set, so the
+// raw device fd is not leaked to child processes across execve.
+func requireCloexec(t *testing.T, path string) {
+	t.Helper()
+	requireFdFlag(t, path, unix.F_GETFD, unix.FD_CLOEXEC, unix.FD_CLOEXEC, "FD_CLOEXEC set")
+}
+
+// requireReadOnly asserts the device fd for path was opened read-only.
+func requireReadOnly(t *testing.T, path string) {
+	t.Helper()
+	requireFdFlag(t, path, unix.F_GETFL, unix.O_ACCMODE, unix.O_RDONLY, "O_RDONLY access mode")
+}

--- a/examples/nvme_linux_test.go
+++ b/examples/nvme_linux_test.go
@@ -20,6 +20,9 @@ func TestNVMe(t *testing.T) {
 	require.NoError(t, err)
 	defer dev.Close()
 
+	requireCloexec(t, path)
+	requireReadOnly(t, path)
+
 	c, ns, err := dev.Identify()
 	require.NoError(t, err)
 

--- a/examples/sata_linux_test.go
+++ b/examples/sata_linux_test.go
@@ -21,6 +21,9 @@ func TestSata(t *testing.T) {
 	require.NoError(t, err)
 	defer dev.Close()
 
+	requireCloexec(t, path)
+	requireReadOnly(t, path)
+
 	i, err := dev.Identify()
 	require.NoError(t, err)
 	fmt.Printf("%+v\n", i)

--- a/examples/scsi_linux_test.go
+++ b/examples/scsi_linux_test.go
@@ -21,6 +21,9 @@ func TestScsi(t *testing.T) {
 	require.NoError(t, err)
 	defer dev.Close()
 
+	requireCloexec(t, path)
+	requireReadOnly(t, path)
+
 	c, err := dev.Capacity()
 	require.NoError(t, err)
 	require.Equal(t, 0x2800000, int(c))

--- a/nvme_linux.go
+++ b/nvme_linux.go
@@ -72,7 +72,7 @@ type NVMeDevice struct {
 }
 
 func OpenNVMe(name string) (*NVMeDevice, error) {
-	fd, err := unix.Open(name, unix.O_RDONLY, 0o600)
+	fd, err := unix.Open(name, unix.O_RDONLY|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/sata_linux.go
+++ b/sata_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func OpenSata(name string) (*SataDevice, error) {
-	fd, err := unix.Open(name, unix.O_RDONLY, 0o600)
+	fd, err := unix.Open(name, unix.O_RDONLY|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/scsi_linux.go
+++ b/scsi_linux.go
@@ -10,7 +10,7 @@ import (
 )
 
 func OpenScsi(name string) (*ScsiDevice, error) {
-	fd, err := unix.Open(name, unix.O_RDONLY, 0o600)
+	fd, err := unix.Open(name, unix.O_RDONLY|unix.O_CLOEXEC, 0o600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Apart from `O_RDONLY`, Linux device descriptors (NVMe, SATA, and SCSI) are now opened also with `O_CLOEXEC`.

The motivation behind this change is that descriptors default to being inherited across `execve`. Since this library hands out fds to raw block devices, and can be used by processes that spawn subprocesses, an un-flagged fd leaks the raw disk into unrelated children. Meaning:
- raw block devices can be exposed to processes that should not have them,
- the device might be kept open way past the parent's `Close()`.

The above can cause fd leakage and exhaustion. 

The new implementation matches Go's own `os.OpenFile` behavior. That is, [`os.OpenFile`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/os/file.go;l=410;drc=8cce3ab20c49a5c3c9fa8e97ad47335c3ccd2620) calls [`os.openFileNolog`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/os/file_unix.go;l=246-261;drc=8cce3ab20c49a5c3c9fa8e97ad47335c3ccd2620), which calls [`os.open`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/os/file_open_unix.go;l=14-17;drc=66cac9e1e4877ac7e66f888b0599a7a4a5787b76) with `syscall.O_CLOEXEC`.

Updates test coverage, also checking for `O_RDONLY` on the open fds.